### PR TITLE
[3.0.1] Add a `username` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the configuration to your mail.php config file:
         'client_secret' => env('GRAPH_API_CLIENT_SECRET'),
 
          // This below is optional. By default we will use the 'from' email address
-        'aad_user_email' => 'myUser@contoso.com'
+        'username' => 'myUser@contoso.com'
     ]
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -14,11 +14,14 @@ Add the configuration to your mail.php config file:
 
 ```php
 'mailers' => [
-    'microsoft-graph' => [
+    'graph-api' => [
         'transport' => 'graph-api',
         'tenant' => env('GRAPH_API_TENANT'),
         'client_id' => env('GRAPH_API_CLIENT_ID'),
-        'client_secret' => env('GRAPH_API_CLIENT_SECRET')
+        'client_secret' => env('GRAPH_API_CLIENT_SECRET'),
+
+         // This below is optional. By default we will use the 'from' email address
+        'aad_user_email' => 'myUser@contoso.com'
     ]
 ]
 ```

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -30,7 +30,7 @@ class Transport extends AbstractTransport
         $email = MessageConverter::toEmail($message->getOriginalMessage());
         $url = sprintf(
             'https://graph.microsoft.com/v1.0/users/%s/sendMail',
-             $this->config['aad_user_email'] ? urlencode($this->config['aad_user_email']) : $email->getFrom()[0]->getEncodedAddress()
+             $this->config['username'] ? urlencode($this->config['username']) : $email->getFrom()[0]->getEncodedAddress()
         );
         $response = Http::withHeaders([
             'Authorization' => sprintf('Bearer %s', $token),

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -28,7 +28,10 @@ class Transport extends AbstractTransport
     {
         $token = $this->getToken();
         $email = MessageConverter::toEmail($message->getOriginalMessage());
-        $url = sprintf('https://graph.microsoft.com/v1.0/users/%s/sendMail', $email->getFrom()[0]->getEncodedAddress());
+        $url = sprintf(
+            'https://graph.microsoft.com/v1.0/users/%s/sendMail',
+             $this->config['aad_user_email'] ? urlencode($this->config['aad_user_email']) : $email->getFrom()[0]->getEncodedAddress()
+        );
         $response = Http::withHeaders([
             'Authorization' => sprintf('Bearer %s', $token),
         ])->post($url, [

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -30,7 +30,7 @@ class Transport extends AbstractTransport
         $email = MessageConverter::toEmail($message->getOriginalMessage());
         $url = sprintf(
             'https://graph.microsoft.com/v1.0/users/%s/sendMail',
-            $this->config['username'] ? urlencode($this->config['username']) : $email->getFrom()[0]->getEncodedAddress()
+            isset($this->config['username']) ? urlencode($this->config['username']) : $email->getFrom()[0]->getEncodedAddress()
         );
         $response = Http::withHeaders([
             'Authorization' => sprintf('Bearer %s', $token),

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -30,7 +30,7 @@ class Transport extends AbstractTransport
         $email = MessageConverter::toEmail($message->getOriginalMessage());
         $url = sprintf(
             'https://graph.microsoft.com/v1.0/users/%s/sendMail',
-             $this->config['username'] ? urlencode($this->config['username']) : $email->getFrom()[0]->getEncodedAddress()
+            $this->config['username'] ? urlencode($this->config['username']) : $email->getFrom()[0]->getEncodedAddress()
         );
         $response = Http::withHeaders([
             'Authorization' => sprintf('Bearer %s', $token),


### PR DESCRIPTION
Currently we pass the "from" email as the user to send as in AAD. This causes issues if we want to send "from" an aliased email address, but use a single user in AAD for sending all emails.