### PR TITLE
Prioritise HTML content if available

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -73,8 +73,8 @@ class Transport extends AbstractTransport
             'replyTo' => $this->getRecipientsCollection($email->getReplyTo()),
             'subject' => $email->getSubject(),
             'body' => [
-                'contentType' => $email->getTextBody() ? 'Text' : 'HTML',
-                'content' => $email->getTextBody() ?? $email->getHtmlBody(),
+                'contentType' => $email->getHtmlBody() ? 'HTML' : 'Text',
+                'content' => $email->getHtmlBody() ?? $email->getTextBody(),
             ],
             'attachments' => $this->getAttachmentsCollection($email->getAttachments()),
         ]);


### PR DESCRIPTION
Previously when both text and HTML versions were available we were always taking the text version.