### PR TITLE
Use correct path for graph api config

### DIFF
--- a/src/Transport.php
+++ b/src/Transport.php
@@ -21,7 +21,7 @@ class Transport extends AbstractTransport
     public function __construct(array $config)
     {
         parent::__construct(null, null);
-        $this->config = $config;
+        $this->config = $config['mailers']['graph-api'];
     }
 
     protected function doSend(SentMessage $message): void


### PR DESCRIPTION
I've found out that the config passed to Transport is the whole mail.php file.

I wasn't sure if the fix should be done in the Transport or in the ServiceProvider class, I've done it in the Transport.